### PR TITLE
Add git to the docker image for full functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o gitmal .
 
+
 FROM alpine
+
+RUN apk add --no-cache git
 
 COPY --from=builder /go/gitmal /bin/gitmal
 


### PR DESCRIPTION
Without git in the docker image, I got the follwing error:
```
panic: failed to list branches: exec: "git": executable file not found in $PATH

goroutine 1 [running]:
main.main()
        /go/main.go:116 +0x22d5
```

This PR adds git to the built, dedicated image for full functionality.